### PR TITLE
Adds more flexibility around uid during ingests

### DIFF
--- a/src/Plugin/migrate/process/FileImport.php
+++ b/src/Plugin/migrate/process/FileImport.php
@@ -34,7 +34,8 @@ use GuzzleHttp\Exception\ServerException;
  *   be used to differentiate it from being a filename. If no trailing slash
  *   is provided the path will be assumed to be the destination filename.
  *   Defaults to "public://".
- * - uid: The uid to attribute the file entity to. Defaults to 0
+ * - uid: The uid to attribute the file entity to. -1 tells the code to use the current
+ *   user; Defaults to 0
  * - move: Boolean, if TRUE, move the file, otherwise copy the file. Only
  *   applies if the source file is local. If the source file is remote it will
  *   be copied. Defaults to FALSE.
@@ -175,7 +176,15 @@ class FileImport extends FileCopy {
     // Get our file entity values.
     $source = $value;
     $destination = $this->getPropertyValue($this->configuration['destination'], $row) ?: 'public://';
+
     $uid = $this->getPropertyValue($this->configuration['uid'], $row) ?: 0;
+
+    \Drupal::logger("Migrate File")->info("Originally, uid is $uid");
+    if ($uid == -1) {
+      $uid = \Drupal::currentUser()->id();
+    }
+    \Drupal::logger("Migrate File")->info("Now uid is $uid");
+
     $id_only = $this->configuration['id_only'];
 
     // If there's no we skip.

--- a/src/Plugin/migrate/process/FileImport.php
+++ b/src/Plugin/migrate/process/FileImport.php
@@ -179,11 +179,9 @@ class FileImport extends FileCopy {
 
     $uid = $this->getPropertyValue($this->configuration['uid'], $row) ?: 0;
 
-    \Drupal::logger("Migrate File")->info("Originally, uid is $uid");
     if ($uid == -1) {
       $uid = \Drupal::currentUser()->id();
     }
-    \Drupal::logger("Migrate File")->info("Now uid is $uid");
 
     $id_only = $this->configuration['id_only'];
 

--- a/src/Plugin/migrate/process/FileRemoteUrl.php
+++ b/src/Plugin/migrate/process/FileRemoteUrl.php
@@ -65,6 +65,12 @@ class FileRemoteUrl extends ProcessPluginBase {
       return NULL;
     }
 
+    \Drupal::logger("Migrate File")->info("Originally, uid is $uid");
+    if ($uid == -1) {
+      $uid = \Drupal::currentUser()->id();
+    }
+    \Drupal::logger("Migrate File")->info("Now uid is $uid");
+
     // Create a file entity.
     $file = File::create([
       'uri' => $value,

--- a/src/Plugin/migrate/process/FileRemoteUrl.php
+++ b/src/Plugin/migrate/process/FileRemoteUrl.php
@@ -65,11 +65,9 @@ class FileRemoteUrl extends ProcessPluginBase {
       return NULL;
     }
 
-    \Drupal::logger("Migrate File")->info("Originally, uid is $uid");
     if ($uid == -1) {
       $uid = \Drupal::currentUser()->id();
     }
-    \Drupal::logger("Migrate File")->info("Now uid is $uid");
 
     // Create a file entity.
     $file = File::create([


### PR DESCRIPTION
This adds the feature that if the migration config sets the uid to -1, then this code will pull the current users ID for file ownership. 
